### PR TITLE
IBX-371: Removed ezsystems/ezmigrationbundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "ezsystems/ezcommerce-shop-ui": "^1.1.x-dev",
         "ezsystems/apache-tika-bundle": "^2.0",
         "ezsystems/comment-bundle": "^3.1",
-        "ezsystems/ezmigrationbundle": "^1.0",
         "ezsystems/job-queue-bundle": "^4.0",
         "ezsystems/payment-core-bundle": "^3.0",
         "ezsystems/stash-bundle": "^0.8",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-371](https://issues.ibexa.co/browse/IBX-371)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes - **information should be added for upgrading that this package has to be manually required, and about the conflict**

> The core of this issue is to remove the ezsystems/migrationbundle.
> 
> This became important since the release of tanoconsulting/ezmigrationbundle2, which technically is kaliop's successor, compatible with our 3.x versions (although still marked as "unstable").
> Our package replaced the original kaliop/ezmigrationbundle, but since this one exists in a separate package and occupies the same PHP namespace, this leads to conflicts if both are installed.

I've done a search to see if `kaliop` is used anywhere else in a commerce installation, and it seems that the only place is the new ibexa migrations in their bridge (which is expected, as it's supposed to convert kaliop files into ours, without kaliop being a dependency).

I've checked basic frontend, BO & console command lists, no issues.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
