### PR TITLE
[CI] Added nightly browser tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,48 @@
+name: Browser tests
+on:
+    schedule:
+        # Run tests every night
+        - cron: "0 0 * * *"
+    workflow_dispatch: ~
+    push:
+        branches:
+            - master
+            - "[0-9]+.[0-9]+"
+    pull_request: ~
+
+jobs:
+    regression-content-setup1:
+        name: "PHP 7.4/PostgreSQL/Varnish/Redis/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "content"
+            project-version: "^3.3.x-dev"
+            test-suite: "--profile=regression --suite=content"
+            test-setup-phase-1: "--profile=regression --suite=setup-content --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-content --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            multirepository: true
+            timeout: 90
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-content-setup2:
+        name: "PHP 7.3/MySQL/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "content"
+            project-version: "^3.3.x-dev"
+            test-suite: "--profile=regression --suite=content"
+            test-setup-phase-1: "--profile=regression --suite=setup-content --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-content --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            multirepository: true
+            php-image: "ezsystems/php:7.3-v2-node14"
+            timeout: 90
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,8 @@
     "type": "metapackage",
     "license": "proprietary",
     "description": "A meta package for installing Ibexa DXP Content edition",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "repositories": [
         {"type": "composer", "url": "https://updates.ibexa.co"}
     ],
@@ -36,6 +38,9 @@
         "ezsystems/payment-core-bundle": "^3.0",
         "ezsystems/stash-bundle": "^0.8",
         "gregwar/captcha-bundle": "^2.1"
+    },
+    "require-dev": {
+        "ibexa/ci-scripts": "^0.1@dev"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Adding nigthly browser tests for the Content edition.

We need `composer install` to pass in this package (which currently fails).
I've decided to add `minimum-stablity` and `prefer-stable` option - they are root-only (https://getcomposer.org/doc/04-schema.md#minimum-stability), so they are not taken into account when Ibexa DXP is installed.