### PR TITLE
[CI] Disabled single multirepo job

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -26,7 +26,7 @@ jobs:
             TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     regression-content-setup2:
-        name: "PHP 7.4/MySQL/Multirepository"
+        name: "PHP 7.4/MySQL"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: "content"
@@ -35,7 +35,6 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-content --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-content --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
-            multirepository: true
             timeout: 90
         secrets:
             SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}


### PR DESCRIPTION
Disabling the multirepo property for a single job - the property is kept for the second one.

IMHO it's not needed to run multirepo tests for all jobs (a single job is enough).

This saves us a bit of time during set up (no need to reinstall database) and allows us to run tests even when there are issues with multirepository in our product.