### PR TITLE
IBX-1627: Removed ibexa/personalization-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "ibexa/fastly": "^4.0.x-dev",
         "ibexa/icons": "^4.0.x-dev",
         "ibexa/personalization": "^4.0.x-dev",
-        "ibexa/personalization-client": "^4.0.x-dev",
         "ibexa/version-comparison": "^4.0.x-dev",
         "ibexa/workflow": "^4.0.x-dev",
         "ibexa/taxonomy": "^4.0.x-dev",


### PR DESCRIPTION
Due to second stage of rebranding process ibexa/personalization-client has been merged into ibexa/personalization and should be removed from DXP dependencies. 

https://github.com/ibexa/personalization/pull/22