### PR TITLE
[Composer] Bumped minimum version of ezsystems/job-queue-bundle to 4.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ezsystems/ezcommerce-shop-ui": "^1.1.x-dev",
         "ezsystems/apache-tika-bundle": "^2.0",
         "ezsystems/comment-bundle": "^3.1",
-        "ezsystems/job-queue-bundle": "^4.0",
+        "ezsystems/job-queue-bundle": "^4.0.3",
         "ezsystems/payment-core-bundle": "^3.0",
         "ezsystems/stash-bundle": "^0.9",
         "gregwar/captcha-bundle": "^2.1"


### PR DESCRIPTION
Failing tests:
https://github.com/ibexa/content/actions/runs/4505522541/jobs/7931339589 (3.3)
https://github.com/ibexa/commerce/actions/runs/4505528385/jobs/7931423854 (3.3)

The installation fails with:
```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  
!!   // Clearing the cache for the behat environment with debug                     
!!   // true                                                                        
!!  
!!  PHP Fatal error:  Class JMS\JobQueueBundle\Entity\Listener\PersistentRelatedEntitiesCollection contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Doctrine\Common\Collections\ReadableCollection::findFirst, Doctrine\Common\Collections\ReadableCollection::reduce) in /var/www/vendor/ezsystems/job-queue-bundle/JMS/JobQueueBundle/Entity/Listener/PersistentRelatedEntitiesCollection.php on line 22
```

This is the same error that was described in https://github.com/ezsystems/JMSJobQueueBundle/pull/8 - and the release 4.0.3 was made to prevent it (https://github.com/ezsystems/JMSJobQueueBundle/releases/tag/v4.0.3)

In the linked failures Composer prefers to install higher version of doctrine/collections:
```
  - Locking doctrine/collections (2.1.2)
```
and lower version of ezsystems/job-queue-bundle:
```
  - Locking ezsystems/job-queue-bundle (v4.0.2)
```

Bumping the minimum version will prevent Composer from doing so.

