### PR TITLE
IBX-11797: [3.3] Bump Node to 20

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -23,7 +23,6 @@ jobs:
         name: "PHP 7.3/Node 20/PostgreSQL/Varnish/Redis/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "content"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=content"
@@ -40,7 +39,6 @@ jobs:
         name: "PHP 7.4/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "content"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=content"
@@ -57,7 +55,6 @@ jobs:
         name: "PHP 8.3/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "content"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=content"

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,9 +20,10 @@ on:
 
 jobs:
     regression-content-setup1:
-        name: "PHP 7.3/Node 14/PostgreSQL/Varnish/Redis/Multirepository"
+        name: "PHP 7.3/Node 20/PostgreSQL/Varnish/Redis/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "content"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=content"
@@ -31,14 +32,15 @@ jobs:
             setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:7.3-node14"
+            php-image: "ghcr.io/ibexa/docker/php:7.3-node20"
             job-count: 2
             timeout: 90
         secrets: inherit
     regression-content-setup2:
-        name: "PHP 7.4/Node 16/MySQL/Multirepository"
+        name: "PHP 7.4/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "content"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=content"
@@ -47,14 +49,15 @@ jobs:
             setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:7.4-node16"
+            php-image: "ghcr.io/ibexa/docker/php:7.4-node20"
             job-count: 2
             timeout: 90
         secrets: inherit
     regression-content-setup3:
-        name: "PHP 8.3/Node 18/MySQL/Multirepository"
+        name: "PHP 8.3/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "content"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=content"
@@ -63,7 +66,7 @@ jobs:
             setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:8.3-node18"
+            php-image: "ghcr.io/ibexa/docker/php:8.3-node20"
             job-count: 2
             timeout: 90
         secrets: inherit


### PR DESCRIPTION
| :ticket: Issue | IBX-11797 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/ci-scripts/pull/139
- https://github.com/ibexa/docker/pull/60


#### Description:
Increased Node version from 14, 16 & 18 to version 20.

Due to sass 1.100 requirement (`">=20.19.0"`).

On v4.6 Node version 18 will be increased to version 20.

#### For QA:
Tested ignoring unsolvable advisories.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
